### PR TITLE
Expose values on enum object

### DIFF
--- a/specs/aenum.js
+++ b/specs/aenum.js
@@ -42,6 +42,7 @@ function AEnum(definitions) {
         }
         this.namesToValues[name] = value;
         this.valuesToNames[value] = name;
+        this[name] = name;
         value++;
     }
 }

--- a/specs/aenum.js
+++ b/specs/aenum.js
@@ -27,21 +27,24 @@ var SpecError = require('./error');
 module.exports.AEnum = AEnum;
 
 function AEnum(definitions) {
-    this.namesToValues = {};
-    this.valuesToNames = {};
+    this._namesToValues = {};
+    this._valuesToNames = {};
     var value = 0;
     for (var index = 0; index < definitions.length; index++) {
         var definition = definitions[index];
         var name = definition.id.name;
         value = definition.value != null ? definition.value : value;
-        if (this.namesToValues[name] !== undefined) {
+        if (this[name] !== undefined) {
+            throw new Error('Can\'t create enum with reserved name ' + name);
+        }
+        if (this._namesToValues[name] !== undefined) {
             throw new Error('Can\'t create enum with duplicate name ' + name + ' for value ' + value);
         }
         if (value > 0x7fffffff) {
             throw new Error('Can\'t create enum with value out of bounds ' + value + ' for name ' + name);
         }
-        this.namesToValues[name] = value;
-        this.valuesToNames[value] = name;
+        this._namesToValues[name] = value;
+        this._valuesToNames[value] = name;
         this[name] = name;
         value++;
     }
@@ -53,18 +56,18 @@ AEnum.prototype.reify = function reify(value) {
     if (typeof value !== 'number') {
         return new Result(SpecError('Can\'t decode ' + typeof value + ' for enum, number expected'));
     }
-    if (this.valuesToNames[value] === undefined) {
+    if (this._valuesToNames[value] === undefined) {
         return new Result(SpecError('Can\'t decode unknown value for enum ' + value));
     }
-    return new Result(null, this.valuesToNames[value]);
+    return new Result(null, this._valuesToNames[value]);
 };
 
 AEnum.prototype.uglify = function uglify(name) {
     if (typeof name !== 'string') {
         return new Result(SpecError('Can\'t encode ' + typeof name + ' for enum, string expected'));
     }
-    if (this.namesToValues[name] === undefined) {
+    if (this._namesToValues[name] === undefined) {
         return new Result(SpecError('Can\'t encode unknown name for enum ' + name));
     }
-    return new Result(null, this.namesToValues[name]);
+    return new Result(null, this._namesToValues[name]);
 };

--- a/test/enum-reserved.thrift
+++ b/test/enum-reserved.thrift
@@ -22,10 +22,9 @@
  */
 
 enum MyEnum {
-    A
-    A
+    hasOwnProperty
 }
 
 struct MyStruct {
-  1: MyEnum enum = MyEnum.A
+  1: MyEnum enum = MyEnum.hasOwnProperty
 }

--- a/test/enum.js
+++ b/test/enum.js
@@ -33,6 +33,16 @@ tape('round trip an enum', function t(assert) {
     assert.end();
 });
 
+tape('round trip an enum (non-string)', function t(assert) {
+    var enumSpec = thriftify.readSpecSync(path.join(__dirname, 'enum.thrift'));
+    var MyEnum3 = enumSpec.types.MyEnum3;
+    var inStruct = {me2_2: null, me3_n2: null, me3_d1: MyEnum3.ME3_D1};
+    var buffer = thriftify.toBuffer(inStruct, enumSpec, 'MyStruct');
+    var outStruct = thriftify.fromBuffer(buffer, enumSpec, 'MyStruct');
+    assert.deepEquals(outStruct, inStruct);
+    assert.end();
+});
+
 tape('first enum is 0 by default', function t(assert) {
     var enumSpec = thriftify.readSpecSync(path.join(__dirname, 'enum.thrift'));
     var inStruct = {me2_2: null, me3_n2: null, me3_d1: 'ME3_0'};

--- a/test/enum.js
+++ b/test/enum.js
@@ -105,6 +105,13 @@ tape('throws on name collision', function t(assert) {
     assert.end();
 });
 
+tape('throws on reserved name', function t(assert) {
+    assert.throws(function throws() {
+        thriftify.readSpecSync(path.join(__dirname, 'enum-reserved.thrift'));
+    });
+    assert.end();
+});
+
 tape('throws on overflow', function t(assert) {
     assert.throws(function throws() {
         thriftify.readSpecSync(path.join(__dirname, 'enum-overflow.thrift'));


### PR DESCRIPTION
@leizha @kriskowal #24 

This is a backwards compatible change for exposing enum values on the spec object. If we are still comfortable with breaking backwards compatibility, I'd change the uglification/reification to purely i32 and forget the strings completely (I have a POC for that in the willEnum branch)