### PR TITLE
Add a placeholder for Set

### DIFF
--- a/compiler/spec.js
+++ b/compiler/spec.js
@@ -37,7 +37,7 @@ function Types() {
     this.i32 = specs.AInt32;
     this.i64 = specs.AInt64;
     this.double = specs.ADouble;
-};
+}
 
 function Spec() {
     this.types = new Types();
@@ -73,11 +73,13 @@ Spec.prototype.setTypeResult = function setType(name, type) {
 Spec.prototype.lookupType = function lookupType(t) {
     // TODO: handle const
     // TODO: handle typedef
-    // TODO: handle Set
+    // TODO: Implement Set semantics
     if (t.type === 'Identifier') {
         return this.getType(t.name);
     } else if (t.type === 'List') {
         return specs.AList(this.lookupType(t.fieldType));
+    } else if (t.type === 'Set') {
+        return specs.ASet(this.lookupType(t.fieldType));
     } else if (t.type === 'Map') {
         return specs.AMap(this.lookupType(t.left), this.lookupType(t.right));
     } else {

--- a/specs/aset.js
+++ b/specs/aset.js
@@ -20,27 +20,25 @@
 
 'use strict';
 
+var util = require('util');
 var thriftrw = require('thriftrw');
+
+var AList = require('./alist').AList;
+var Result = require('../result');
+var SpecError = require('./error');
+
 var TYPE = thriftrw.TYPE;
 
-module.exports.ABoolean = require('./aboolean').ABoolean();
+function ASet(etype) {
+    if (!(this instanceof ASet)) {
+        return new ASet(etype);
+    }
+    this.typeid = TYPE.SET;
+    this.etype = etype;
+}
 
-var AInteger = require('./ainteger').AInteger;
-module.exports.AByte = AInteger(TYPE.BYTE);
-module.exports.AInt16 = AInteger(TYPE.I16);
-module.exports.AInt32 = AInteger(TYPE.I32);
+// TODO: Imeplment set semantics
 
-module.exports.ADouble = require('./adouble').ADouble();
+util.inherits(ASet, AList);
 
-module.exports.AInt64 = require('./aint64').AInt64();
-
-module.exports.AString = require('./astring').AString();
-module.exports.ABinary = require('./abinary').ABinary();
-
-module.exports.AMap = require('./amap').AMap;
-module.exports.AList = require('./alist').AList;
-module.exports.ASet = require('./aset').ASet;
-module.exports.AField = require('./astruct').AField;
-module.exports.AStruct = require('./astruct').AStruct;
-module.exports.AEnum = require('./aenum').AEnum;
-module.exports.AResult = require('./aresult').AResult;
+module.exports.ASet = ASet;

--- a/specs/test/index.js
+++ b/specs/test/index.js
@@ -42,6 +42,14 @@ test('reify and uglify', function t(assert) {
             [1, 2, 3]
         ],
         [
+            specs.ASet(specs.AStruct({
+                fields: [
+                  specs.AField({id: 1, name: 'foo', type: specs.AInt32})
+                ]
+            })),
+            [{foo: 1}, {foo: 2}]
+        ],
+        [
             specs.AStruct({
                 fields: [
                     specs.AField({id: 1, name: 'a', type: specs.AString}),


### PR DESCRIPTION
@leizha @kriskowal @jcorbin 

I need to be able to use the Set construct. This creates a placeholder for a Set which behaves like a list and does not implement the Set semantics. This is preferable to changing to a list in the thrift file because changing back would require lots of 'SomethingV2' structs which I'd like to avoid for a new service.

I'll follow up with an implementation of the set semantics shortly.