### PR TITLE
WIP: Set implementation

### DIFF
--- a/compiler/spec.js
+++ b/compiler/spec.js
@@ -37,7 +37,7 @@ function Types() {
     this.i32 = specs.AInt32;
     this.i64 = specs.AInt64;
     this.double = specs.ADouble;
-}
+};
 
 function Spec() {
     this.types = new Types();
@@ -73,7 +73,6 @@ Spec.prototype.setTypeResult = function setType(name, type) {
 Spec.prototype.lookupType = function lookupType(t) {
     // TODO: handle const
     // TODO: handle typedef
-    // TODO: Implement Set semantics
     if (t.type === 'Identifier') {
         return this.getType(t.name);
     } else if (t.type === 'List') {

--- a/package.json
+++ b/package.json
@@ -17,12 +17,14 @@
     }
   ],
   "dependencies": {
-    "pegjs": "^0.8.0",
-    "lodash": "^3.5.0",
-    "thriftrw": "v1.0.0-beta3",
+    "buffer-equal": "0.0.1",
     "bufrw": "^0.9.19",
     "debug": "^2.1.3",
-    "error": "^6.0.0"
+    "error": "^6.0.0",
+    "lodash": "^3.5.0",
+    "pegjs": "^0.8.0",
+    "thriftrw": "v1.0.0-beta3",
+    "uniq": "^1.0.1"
   },
   "devDependencies": {
     "coveralls": "^2.10.0",


### PR DESCRIPTION
This is a WIP implementation of set semantics. It would require adding the method `getRW` to `thriftrw` in order to be able to lookup the correct RW for atomic types.

The other alternative is to implement some kind of `equals` comparison function on every type directly. I thought this was simpler, though may not be as clean. What do you guys think is the best way to do this? @kriskowal @Raynos @leizha 