### PR TITLE
Support maps of enum keys

### DIFF
--- a/specs/aenum.js
+++ b/specs/aenum.js
@@ -27,6 +27,10 @@ var SpecError = require('./error');
 module.exports.AEnum = AEnum;
 
 function AEnum(definitions) {
+    if (!(this instanceof AEnum)) {
+        return new AEnum(definitions);
+    }
+
     this.namesToValues = {};
     this.valuesToNames = {};
     var value = 0;

--- a/specs/amap.js
+++ b/specs/amap.js
@@ -48,6 +48,16 @@ function AMap(ktype, vtype) {
 }
 
 AMap.prototype.reify = function reify(tmap) {
+
+    // re-ify maps of I32 as string keys for JS.
+    if(tmap.ktypeid === TYPE.I32) {
+        tmap.ktypeid = TYPE.STRING;
+        tmap.pairs = tmap.pairs.map(function itos(pair) {
+            pair.key = new Buffer(String(pair.key));
+            return pair;
+        });
+    }
+
     if (this.ktype.typeid !== tmap.ktypeid) {
         return new Result(SpecError(util.format('AMap::reify expects ktypeid %d; received %d',
             this.ktype.typeid, tmap.ktypeid)));

--- a/specs/amap.js
+++ b/specs/amap.js
@@ -34,8 +34,8 @@ function AMap(ktype, vtype) {
     }
     this.typeid = TYPE.MAP;
 
-    if (ktype.typeid !== TYPE.STRING) {
-        throw new Error('key type has to be TYPE.STRING; received %d', ktype.typeid);
+    if (ktype.typeid !== TYPE.STRING && ktype.typeid !== TYPE.I32) {
+        throw new Error(util.format('key type has to be TYPE.STRING or TYPE.I32; received %d', ktype.typeid));
     }
     this.ktype = ktype;
     this.vtype = vtype;

--- a/specs/amap.js
+++ b/specs/amap.js
@@ -41,7 +41,7 @@ function AMap(ktype, vtype) {
     }
 
     if (ktype.typeid !== TYPE.STRING) {
-        throw new Error(util.format('key type has to be TYPE.STRING ; received %d', ktype.typeid));
+        throw new Error(util.format('key type has to be TYPE.STRING; received %d', ktype.typeid));
     }
     this.ktype = ktype;
     this.vtype = vtype;

--- a/specs/amap.js
+++ b/specs/amap.js
@@ -27,6 +27,7 @@ var util = require('util');
 var owns = Object.prototype.hasOwnProperty;
 var Result = require('../result');
 var SpecError = require('./error');
+var AString = require('./astring').AString;
 
 function AMap(ktype, vtype) {
     if (!(this instanceof AMap)) {
@@ -34,8 +35,13 @@ function AMap(ktype, vtype) {
     }
     this.typeid = TYPE.MAP;
 
-    if (ktype.typeid !== TYPE.STRING && ktype.typeid !== TYPE.I32) {
-        throw new Error(util.format('key type has to be TYPE.STRING or TYPE.I32; received %d', ktype.typeid));
+    // Treat numeric keys types as strings as all object properties are strings in JavaScript
+    if (ktype.typeid === TYPE.I32) {
+        ktype = AString();
+    }
+
+    if (ktype.typeid !== TYPE.STRING) {
+        throw new Error(util.format('key type has to be TYPE.STRING ; received %d', ktype.typeid));
     }
     this.ktype = ktype;
     this.vtype = vtype;

--- a/specs/test/index.js
+++ b/specs/test/index.js
@@ -53,6 +53,10 @@ test('reify and uglify', function t(assert) {
             {foo: 1, bar: 2}
         ],
         [
+            specs.AMap(specs.AInt32, specs.AString),
+            {1: 'foo', 2: 'bar'}
+        ],
+        [
             specs.ASet(specs.AStruct({
                 fields: [
                   specs.AField({id: 1, name: 'foo', type: specs.AInt32})

--- a/specs/test/index.js
+++ b/specs/test/index.js
@@ -104,9 +104,9 @@ test('reify and uglify', function t(assert) {
             }),
             {a: 'hello', b: 123, x: {c: '[', d: ']'}}
         ]
-    ], function each(pair) {
-        var spec = pair[0];
-        var val = pair[1];
+    ], function each(triple) {
+        var spec = triple[0];
+        var val = triple[1];
 
         var t = spec.uglify(val);
         if (t.err) {
@@ -124,13 +124,11 @@ test('reify and uglify', function t(assert) {
 
         assert.deepEqual(back, val);
 
-
-        if(pair[2]) {
-            debugger;
-            var rwObj = pair[2];
-            var re = spec.reify(rwObj);
-            var ug = spec.uglify(re.value);
-            assert.deepEqual(rwObj, ug.value);
+        if(triple[2]) {
+            var thriftRWObj = triple[2];
+            var reified = spec.reify(thriftRWObj);
+            var uglified = spec.uglify(reified.value);
+            assert.deepEqual(thriftRWObj, uglified.value);
         }
     });
     assert.end();

--- a/specs/test/index.js
+++ b/specs/test/index.js
@@ -42,6 +42,17 @@ test('reify and uglify', function t(assert) {
             [1, 2, 3]
         ],
         [
+            specs.AMap(specs.AString, specs.AInt32),
+            {foo: 1, bar: 2}
+        ],
+        [
+            specs.AMap(specs.AEnum([
+                    {id: {name: 'foo'}, value: 1},
+                    {id: {name: 'bar'}, value: 2}
+                ]), specs.AInt32),
+            {foo: 1, bar: 2}
+        ],
+        [
             specs.ASet(specs.AStruct({
                 fields: [
                   specs.AField({id: 1, name: 'foo', type: specs.AInt32})


### PR DESCRIPTION
@leizha @kriskowal 

Fixes https://github.com/uber/thriftify/issues/30

This allows the use of I32 keys (and therefore enums) for maps.