### PR TITLE
upgrade thriftrw to prevent cyclic proto bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "pegjs": "^0.8.0",
     "lodash": "^3.5.0",
-    "thriftrw": "v1.0.0-beta3",
-    "bufrw": "^0.9.19",
+    "thriftrw": "^3.4.3",
+    "bufrw": "^1.2.1",
     "debug": "^2.1.3",
     "error": "^6.0.0"
   },


### PR DESCRIPTION
When running anything that relies on `bufrw` < https://github.com/uber/bufrw/commit/4a9a3578a44c3f6465027e9e403575f4ac8052f9#diff-5dd6068dbc61bb8d393017edb5392d87R50 on modern node versions, we get this error:

```
TypeError: Cyclic __proto__ value
    at Function.setPrototypeOf (native)
    at exports.inherits (util.js:900:10)
    at Object.<anonymous> (/Users/aleksey/node-m3-client-addon/node_modules/bufrw/switch.js:49:1)
```

This is due to a typo/bug in bufrw that was fixed a while ago. 
